### PR TITLE
Minor adjustments

### DIFF
--- a/static-haskell-nix/default.nix
+++ b/static-haskell-nix/default.nix
@@ -15,8 +15,8 @@ let
         executableHaskellDepends = [ base scotty ];
         license = stdenv.lib.licenses.bsd3;
         configureFlags = [
+          "--disable-shared"
           "--ghc-option=-optl=-static"
-          "--ghc-option=-optl=-pthread"
           "--ghc-option=-optl=-L${pkgs.gmp5.static}/lib"
           "--ghc-option=-optl=-L${pkgs.zlib.static}/lib"
           "--ghc-option=-optl=-L${pkgs.glibc.static}/lib"


### PR DESCRIPTION
`--disable-shared` ensures that you don't fall back to the default of `--enable-shared` for `configure`. Maybe you didn't run into that issue because you ran `cabal configure --disable-executable-dynamic`, and cabal picked up the configure state from there.

The `-pthread` should not be necessary, ghc should add this on it's own when asking for `-threaded` and the system requires libpthread.  You'd end up with `-lpthread` twice in the linker arguments.